### PR TITLE
Implemented getAllComments method 

### DIFF
--- a/src/main/java/net/rcarz/jiraclient/Issue.java
+++ b/src/main/java/net/rcarz/jiraclient/Issue.java
@@ -1564,6 +1564,19 @@ public class Issue extends Resource {
         return comments;
     }
 
+    public List<Comment> getAllComments() throws JiraException {
+        JSONObject obj;
+        try {
+            URI uri = restclient.buildURI(getBaseUri() + "issue/" + key + "/comment");
+            JSON json = restclient.get(uri);
+            obj = (JSONObject) json;
+        } catch (Exception ex) {
+            throw new JiraException("Failed to get comments for issue "
+                    + key, ex);
+        }
+        return Field.getComments(obj, restclient, key);
+    }
+
     public List<Component> getComponents() {
         return components;
     }


### PR DESCRIPTION
If issues are fetched via a Jira Search, then comments for each issue will be missed and getComments() method will return an empty list. Thus, implemented a method getAllComments (similarly to getAllWorklogs) that will fetch all comments for the given Issue (a new rest call will be sent to Jira server).